### PR TITLE
Add events from `trlist.NlxEventTTL`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ Repository="https://github.com/catalystneuro/schwerdt-lab-to-nwb"
 amjad_2025 = [
     "neuroconv[neuralynx]==0.7.5",   # Pinned dependencies to specific versions
     "pymatreader",
+    "ndx-events==0.2.1"
 ]
 
 [build-system]

--- a/src/schwerdt_lab_to_nwb/amjad_2025/conversion_notes.md
+++ b/src/schwerdt_lab_to_nwb/amjad_2025/conversion_notes.md
@@ -46,7 +46,14 @@ Spikes
 - `FSCV_trlists_c8dg_09132024_firsthalf.mat` - Processed FSCV data, aligned to behavioral events, fscv contains processed (PCA extracted) signals from the site name that is mentioned in fscvnames (c8dg). eventmap contains information about what each behavioral code in trlist.NlxEventTTL means.
 
 ### Behavioral data
-- `09262024_trlist.mat` - Behavioral data with each row corresponding to a trial in the session.
+
+- `09262024_trlist.mat` - Contains behavioral data for each trial in the session. The file includes:
+  - `ts`: An array of timestamps for the start of each trial.
+  - `type`: An array of trial types or tags.
+  - `NlxEventTS`: Nested arrays of event timestamps for each trial.
+  - `NlxEventTTL`: Nested arrays of event codes for each trial, which can be mapped to event names using `eventmap`.
+
+This data is used to populate the NWB file's trials table and events table. The trials table includes start and stop times for each trial, while the events table contains detailed event information aligned to the trials.
 
 ### Session start time
 

--- a/src/schwerdt_lab_to_nwb/amjad_2025/convert_session.py
+++ b/src/schwerdt_lab_to_nwb/amjad_2025/convert_session.py
@@ -68,9 +68,12 @@ def session_to_nwb(
         trlist_file_path = trlist_file_paths[0]
         source_data.update(dict(Behavior=dict(file_path=trlist_file_path, trials_key="trlist")))
         if ttl_code_to_event_name is not None:
-            conversion_options.update(dict(Behavior=dict(event_mapping=ttl_code_to_event_name, stub_test=False)))
+            conversion_options.update(dict(Behavior=dict(event_mapping=ttl_code_to_event_name, stub_test=stub_test)))
         else:
-            conversion_options.update(dict(Behavior=dict(stub_test=stub_test)))
+            raise ValueError(
+                f"TTL code to event name mapping is required when '{trlist_file_path}' is specified. "
+                "Please provide this mapping using the 'event_mapping' argument."
+            )
 
     converter = Amjad2025NWBConverter(source_data=source_data, verbose=verbose)
 

--- a/src/schwerdt_lab_to_nwb/amjad_2025/convert_session.py
+++ b/src/schwerdt_lab_to_nwb/amjad_2025/convert_session.py
@@ -14,6 +14,7 @@ def session_to_nwb(
     session_folder_path: DirectoryPath,
     nwb_folder_path: DirectoryPath,
     channel_name_to_brain_area: dict[str, str] | None = None,
+    ttl_code_to_event_name: dict[int, str] | None = None,
     stub_test: bool = False,
     verbose: bool = False,
 ):
@@ -31,6 +32,9 @@ def session_to_nwb(
         The file will be named 'sub-{subject_id}_ses-{session_id}.nwb'.
     channel_name_to_brain_area : dict[str, str] | None, optional
         A dictionary mapping channel names to brain areas.
+        If provided, the brain area will be set for each channel in the NWB file.
+    ttl_code_to_event_name : dict[int, str] | None, optional
+        A dictionary mapping TTL event codes to event names.
     stub_test : bool, optional
         Whether to run conversion in stub test mode (not implemented), by default False.
     verbose : bool, optional
@@ -63,7 +67,10 @@ def session_to_nwb(
     if len(trlist_file_paths) == 1:
         trlist_file_path = trlist_file_paths[0]
         source_data.update(dict(Behavior=dict(file_path=trlist_file_path, trials_key="trlist")))
-        conversion_options.update(dict(Behavior=dict(stub_test=False)))
+        if ttl_code_to_event_name is not None:
+            conversion_options.update(dict(Behavior=dict(event_mapping=ttl_code_to_event_name, stub_test=False)))
+        else:
+            conversion_options.update(dict(Behavior=dict(stub_test=stub_test)))
 
     converter = Amjad2025NWBConverter(source_data=source_data, verbose=verbose)
 
@@ -125,10 +132,74 @@ if __name__ == "__main__":
         "CSC38": "c3a",
     }
 
+    # TODO: Extract this from file when available
+    # 40, 41, 0 missing from trlists.eventmap
+    event_code_dict = {
+        9: "start trial",
+        12: "frame skipped",
+        14: "manual reward",
+        18: "end trial",
+        21: "feedback",
+        23: "value object start",
+        24: "central cue end",
+        26: "forced forced value cue start",
+        27: "forced forced value cue only",
+        28: "onedr",
+        30: "left cue reward condition 1",
+        31: "left cue reward condition 2",
+        32: "left cue reward condition 3",
+        33: "left cue reward condition 4",
+        34: "left cue reward condition 5",
+        35: "right cue reward condition 1",
+        36: "right cue reward condition 2",
+        37: "right cue reward condition 3",
+        38: "right cue reward condition 4",
+        39: "right cue reward condition 5",
+        50: "central cue fixation started",
+        51: "value cue fixation started",
+        52: "forced trial valuecue fix allowed",
+        53: "forced trial valuecue fix started",
+        60: "error fixation break target",
+        61: "error fixation break initial",
+        62: "error fixation never started",
+        63: "error fixation break central cue value object",
+        64: "error choice never made",
+        65: "error choice value initial fix break",
+        66: "error choice fixbreak right",
+        67: "error choice fixbreak left",
+        68: "error forced trial value cue fix never started",
+        69: "error forced trial value cue fix break",
+        81: "image 1",
+        82: "image 2",
+        83: "image 3",
+        84: "image 4",
+        85: "image 5",
+        86: "image 6",
+        87: "image 7",
+        88: "image 8",
+        89: "image 9",
+        90: "image 10",
+        100: "small reward",
+        101: "big reward",
+        102: "airpuff on",
+        103: "airpuff off",
+        105: "reward delivery end",
+        115: "transient value condition",
+        116: "fixed value condition",
+        117: "left condition",
+        118: "right condition",
+        119: "forced trial condition",
+        120: "choice trial condition",
+        121: "right choice chosen code",
+        122: "left choice chosen code",
+        128: "trial start",  # or initial central cue start
+    }
+
     session_to_nwb(
         session_folder_path=data_dir_path,
         nwb_folder_path=output_dir_path,
         channel_name_to_brain_area=channel_name_to_brain_area,
+        ttl_code_to_event_name=event_code_dict,
         stub_test=stub_test,
     )
 
@@ -151,3 +222,8 @@ if __name__ == "__main__":
         assert_array_equal(
             nwbfile.electrodes["location"][:], ["c3bs", "c3a"]
         ), "Expected brain areas to match the provided dictionary."
+        # check that the events are present
+        assert (
+            nwbfile.processing["events"]["events_table"] is not None
+        ), "Expected events table to be present in the NWB file."
+        print(nwbfile.processing["events"]["events_table"][:].head())

--- a/src/schwerdt_lab_to_nwb/amjad_2025/convert_session.py
+++ b/src/schwerdt_lab_to_nwb/amjad_2025/convert_session.py
@@ -133,9 +133,9 @@ if __name__ == "__main__":
     }
 
     # TODO: Extract this from file when available
-    # 40, 41, 0 missing from trlists.eventmap
+    # 40, 41, 0 missing from trlists.eventmap can be skipped
     event_code_dict = {
-        9: "start trial",
+        # 9: "start trial", code 9 can be skipped
         12: "frame skipped",
         14: "manual reward",
         18: "end trial",

--- a/src/schwerdt_lab_to_nwb/amjad_2025/metadata.yaml
+++ b/src/schwerdt_lab_to_nwb/amjad_2025/metadata.yaml
@@ -46,3 +46,9 @@ Ecephys:
   electrical_series:
     name: electrical_series
     description: The raw acquisition traces from Neuralynx (Digital Lynx SX) acquired with a unity-gain headstage (Neuralynx, HS-36, ±1 mV input range, at 30 or 32 kHz).
+
+Events:
+  AnnotatedEventsTable:
+    name: events_table
+    description: |
+      This table contains the events related to the task performance, including timestamps for task initiation, reward delivery, and other significant behavioral events.

--- a/src/schwerdt_lab_to_nwb/amjad_2025/nwbconverter.py
+++ b/src/schwerdt_lab_to_nwb/amjad_2025/nwbconverter.py
@@ -6,7 +6,7 @@ from neuroconv.datainterfaces import (
     PlexonSortingInterface,
 )
 
-from schwerdt_lab_to_nwb.interfaces import TrialsInterface
+from schwerdt_lab_to_nwb.interfaces import BehaviorInterface
 
 
 class Amjad2025NWBConverter(NWBConverter):
@@ -15,5 +15,5 @@ class Amjad2025NWBConverter(NWBConverter):
     data_interface_classes = dict(
         Recording=NeuralynxRecordingInterface,
         Sorting=PlexonSortingInterface,
-        Behavior=TrialsInterface,
+        Behavior=BehaviorInterface,
     )

--- a/src/schwerdt_lab_to_nwb/interfaces/__init__.py
+++ b/src/schwerdt_lab_to_nwb/interfaces/__init__.py
@@ -1,1 +1,5 @@
-from .trials_interface import TrialsInterface
+from .behavior_interface import BehaviorInterface
+
+__all__ = [
+    "BehaviorInterface",
+]

--- a/src/schwerdt_lab_to_nwb/interfaces/behavior_interface.py
+++ b/src/schwerdt_lab_to_nwb/interfaces/behavior_interface.py
@@ -15,7 +15,7 @@ from schwerdt_lab_to_nwb.utils import (
 )
 
 
-class TrialsInterface(BaseDataInterface):
+class BehaviorInterface(BaseDataInterface):
     """
     Data interface for adding trial and event information to an NWBFile from MATLAB .mat files.
 
@@ -43,7 +43,7 @@ class TrialsInterface(BaseDataInterface):
 
     def __init__(self, file_path: FilePath, trials_key: str, verbose: bool = False):
         """
-        Initialize the TrialsInterface.
+        Initialize the BehaviorInterface.
 
         Parameters
         ----------

--- a/src/schwerdt_lab_to_nwb/interfaces/trials_interface.py
+++ b/src/schwerdt_lab_to_nwb/interfaces/trials_interface.py
@@ -17,16 +17,22 @@ from schwerdt_lab_to_nwb.utils import (
 
 class TrialsInterface(BaseDataInterface):
     """
-    Data interface for adding trial information to an NWBFile from MATLAB .mat files.
+    Data interface for adding trial and event information to an NWBFile from MATLAB .mat files.
 
-    This interface reads trial data (e.g., start/stop times, trial types) from a .mat file and adds it to the NWBFile
-    in the standard trials table. The .mat file must contain a key (default: 'trlist') with a dictionary that includes
-    at least a 'ts' (timestamps) array and a 'type' array for trial tags.
+    This interface reads trial data (e.g., start/stop times, trial types) and event data (e.g., timestamps, event codes)
+    from a .mat file and adds them to the NWBFile. Trial data is added to the standard trials table, while event data
+    is added using an AnnotatedEventsTable.
+
+    The .mat file must contain a key (default: 'trlist') with a dictionary that includes at least:
+    - 'ts': an array of timestamps for trials.
+    - 'type': an array of trial tags.
+    - 'NlxEventTS': nested arrays of event timestamps per trial.
+    - 'NlxEventTTL': nested arrays of event codes per trial.
 
     Parameters
     ----------
     file_path : FilePath
-        Path to the .mat file containing trial data.
+        Path to the .mat file containing trial and event data.
     trials_key : str
         Key in the .mat file dictionary that contains the trial data.
     verbose : bool, optional
@@ -130,7 +136,7 @@ class TrialsInterface(BaseDataInterface):
                 check_ragged=False,
             )
 
-    def add_events(
+    def add_events_to_nwbfile(
         self,
         nwbfile: NWBFile,
         event_mapping: dict,
@@ -148,6 +154,8 @@ class TrialsInterface(BaseDataInterface):
             Mapping of event codes to labels for the AnnotatedEventsTable.
         metadata : dict or None
             Metadata dictionary for the NWB file, which should include session start time.
+        stub_test : bool, optional
+            If True, only a subset of events will be added for testing.
         """
         from ndx_events import AnnotatedEventsTable
 
@@ -208,18 +216,18 @@ class TrialsInterface(BaseDataInterface):
         stub_test: bool = False,
     ) -> None:
         """
-        Adds the trials data to the NWB file using the standard NeuroConv interface.
+        Adds trials and events data to the NWB file.
 
         Parameters
         ----------
         nwbfile : NWBFile
-            The NWB file to which the trials data will be added.
+            The NWB file to which the trials and events data will be added.
         event_mapping : dict
             Mapping of event codes to labels for the AnnotatedEventsTable.
         metadata : dict or None
-            Metadata dictionary for the NWB file.
+            Metadata dictionary for the NWB file, which should include session start time.
         stub_test : bool, optional
-            If True, only a subset of trials will be added for testing.
+            If True, only a subset of trials and events will be added for testing.
         """
-        self.add_events(nwbfile=nwbfile, metadata=metadata, event_mapping=event_mapping, stub_test=stub_test)
+        self.add_events_to_nwbfile(nwbfile=nwbfile, metadata=metadata, event_mapping=event_mapping, stub_test=stub_test)
         self.add_trials_to_nwbfile(nwbfile=nwbfile, metadata=metadata, stub_test=stub_test)


### PR DESCRIPTION
Add events from behavior `.mat` file (`09262024_trlist.mat`)
- Renamed `TrialsInterface` to `BehaviorInterface`to handle both trial and event data (as `AnnotatedEventsTable`) 
- Added `ttl_code_to_event_name` parameter in `session_to_nwb` to allow writing the descriptive name of labels for the event times.
- Updated `metadata.yaml` to include a description of the `events_table`
- Updated `conversion_notes.md` with detailed descriptions of the behavioral data structure and its mapping to NWB file
- Added `ndx-events==0.2.1` dependency  to support the `AnnotatedEventsTable`
