### PR TITLE
Add subject metadata

### DIFF
--- a/src/schwerdt_lab_to_nwb/amjad_2025/metadata.yaml
+++ b/src/schwerdt_lab_to_nwb/amjad_2025/metadata.yaml
@@ -27,12 +27,20 @@ NWBFile:
     - Schwerdt, Helen N.
     - Amjad, Usamma
   protocol: https://doi.org/10.17504/protocols.io.kqdg32b91v25/v1, https://doi.org/10.17504/protocols.io.x54v92wd4l3e/v1, https://doi.org/10.17504/protocols.io.bp2l62m95gqe/v1
-Subject:
-  species: Macaca mulatta
-  description: Two adult female rhesus monkeys were used for in vivo validation of the s-µIP device, with chronic implants targeting the striatum for simultaneous FSCV and EPhys recordings during behavioral tasks.
-  age: P8Y  # TODO: replace placeholder value (in ISO 8601, such as "P8Y" (example: 8 years))
-  sex: F
-  # date_of_birth: TBD  # Actual date not specified in methods
+
+Subjects:
+  Monkey T:
+    subject_id: Monkey T
+    age: P11Y # 11 years in ISO 8601
+    species: Macaca mulatta
+    sex: F
+    description: Two adult female rhesus monkeys were used for in vivo validation of the s-µIP device, with chronic implants targeting the striatum for simultaneous FSCV and EPhys recordings during behavioral tasks.
+  Monkey P:
+    subject_id: Monkey P
+    age: P8Y # 8 years in ISO 8601
+    species: Macaca mulatta
+    sex: F
+    description: Two adult female rhesus monkeys were used for in vivo validation of the s-µIP device, with chronic implants targeting the striatum for simultaneous FSCV and EPhys recordings during behavioral tasks.
 
 Ecephys:
   Device:


### PR DESCRIPTION

* Updated `metadata.yaml` to use a `Subjects` section containing metadata for multiple subjects (`Monkey T` and `Monkey P`)
* Modified the `session_to_nwb` function to require a `subject_key` argument, which is used to select the appropriate subject metadata from the `Subjects` section. [[1]](diffhunk://#diff-cb97f240328a490a81405e088febe46ef8002b9c0708a99498df737f574366eaR16) [[2]](diffhunk://#diff-cb97f240328a490a81405e088febe46ef8002b9c0708a99498df737f574366eaR34-R35)
* Added error handling to raise a clear exception if the provided `subject_key` is not found in the metadata.
