### PR TITLE
Small updates to behavior interface

### DIFF
--- a/src/schwerdt_lab_to_nwb/interfaces/behavior_interface.py
+++ b/src/schwerdt_lab_to_nwb/interfaces/behavior_interface.py
@@ -204,7 +204,7 @@ class BehaviorInterface(BaseDataInterface):
                 continue
             annotated_events.add_event_type(
                 label=str(label),
-                event_description=f"The event times for code '{event_type}'.",
+                event_description=f"The event times for code '{int(event_type)}'.",
                 event_times=times,
                 check_ragged=False,
             )

--- a/src/schwerdt_lab_to_nwb/interfaces/behavior_interface.py
+++ b/src/schwerdt_lab_to_nwb/interfaces/behavior_interface.py
@@ -79,6 +79,10 @@ class BehaviorInterface(BaseDataInterface):
             raise ValueError(f"Unsupported file format: {file_path_suffix}. Only .mat files are supported.")
 
         trials_list_from_mat = read_mat(file_path)
+        # Common variation in file structure to account for
+        if "trlists" in trials_list_from_mat:
+            trials_list_from_mat = trials_list_from_mat["trlists"]
+
         trials_key = self.source_data.get("trials_key", "trlist")
         if trials_key not in trials_list_from_mat:
             raise KeyError(f"Key '{trials_key}' not found in the .mat file.")


### PR DESCRIPTION
* Added a check for the `"trlists"` key in the data loaded from `.mat` files, ensuring compatibility with common variations in file structure.

* Updated the event description to explicitly cast `event_type` to an integer